### PR TITLE
Add connection retry behavior on all errors

### DIFF
--- a/feed.js
+++ b/feed.js
@@ -57,7 +57,10 @@ newStream();
 
 const evtSource = new EventSource('https://www.blaseball.com/events/streamGameData', {
   initialRetryDelayMillis: 2000,
-  maxBackoffMillis: 5000
+  maxBackoffMillis: 5000,
+  errorFilter: function errorFilter() {
+    return true;
+  },
 });
 let latestGameDataState = {};
 evtSource.on('message', (evt) => {


### PR DESCRIPTION
Fixes feed archive script crashes caused by error responses that aren't 500, 502, 503, and 504